### PR TITLE
Windows Fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,16 @@ NRFUTIL = adafruit-nrfutil
 NRFJPROG = nrfjprog
 
 # Set make directory command, Windows tries to create a directory named "-p" if that flag is there.
-ifneq ($(OS), Windows_NT)
-  MK = mkdir -p
-else
+#ifneq ($(OS), Windows_NT)
+#  MK = mkdir -p
+#else
   MK = mkdir
-endif
-
+#endif
+ifneq ($(OS), Windows_NT)
+RM = rm /S /Q
+else
 RM = rm -rf
+endif
 
 # auto-detect BMP on macOS, otherwise have to specify
 BMP_PORT ?= $(shell ls -1 /dev/cu.usbmodem????????1 | head -1)


### PR DESCRIPTION
hello,

Your environment may be different, but I have proposed a modification for use with MSYS2 in a Windows environment.
I installed make with MSYS2(```$ pacman -S make```), built a Python3 environment, and created a Bootloader.

This cannot be executed because mkdir does not have the -p option.
Since rmdir can only delete empty folders, the /S /Q option is added.
thank you,